### PR TITLE
Fixed a bug where multiple category ids could not be obtained

### DIFF
--- a/keypoint_detection/data/coco_dataset.py
+++ b/keypoint_detection/data/coco_dataset.py
@@ -125,7 +125,7 @@ class COCOKeypointsDataset(ImageDataset):
                 # add all keypoints from this annotation to the corresponding image in the dict
 
                 img = img_dict[annotation.image_id]
-                category = category_dict[category.id]
+                category = category_dict[annotation.category_id]
                 semantic_classes = category.keypoints
 
                 keypoints = annotation.keypoints


### PR DESCRIPTION
Changing `category = category_dict[category.id]` to `category = category_dict[annotation.category_id]` in `coco_dataset.py` 128th line.