### PR TITLE
added argument for max amount of keypoints

### DIFF
--- a/keypoint_detection/models/detector.py
+++ b/keypoint_detection/models/detector.py
@@ -417,7 +417,9 @@ class KeypointDetector(pl.LightningModule):
         heatmap (torch.Tensor) : H x W tensor that represents a heatmap.
         """
 
-        detected_keypoints = get_keypoints_from_heatmap(heatmap, self.minimal_keypoint_pixel_distance, self.max_keypoints)
+        detected_keypoints = get_keypoints_from_heatmap(
+            heatmap, self.minimal_keypoint_pixel_distance, self.max_keypoints
+        )
         keypoint_probabilities = compute_keypoint_probability(heatmap, detected_keypoints)
         detected_keypoints = [
             DetectedKeypoint(detected_keypoints[i][0], detected_keypoints[i][1], keypoint_probabilities[i])

--- a/keypoint_detection/models/detector.py
+++ b/keypoint_detection/models/detector.py
@@ -70,6 +70,12 @@ class KeypointDetector(pl.LightningModule):
             type=float,
             help="relative threshold for the OnPlateauLRScheduler. If the training epoch loss does not decrease with this fraction for 2 consective epochs, lr is decreased with factor 10.",
         )
+        parser.add_argument(
+            "--max_keypoints",
+            default=-1,
+            type=int,
+            help="the maximum number of keypoints to predict from the generated heatmaps. If set to -1, skimage will look for all peaks in the heatmap, if set to N (N>0) it will return the N most most certain ones.",
+        )
         return parent_parser
 
     def __init__(
@@ -409,7 +415,7 @@ class KeypointDetector(pl.LightningModule):
         heatmap (torch.Tensor) : H x W tensor that represents a heatmap.
         """
 
-        detected_keypoints = get_keypoints_from_heatmap(heatmap, self.minimal_keypoint_pixel_distance)
+        detected_keypoints = get_keypoints_from_heatmap(heatmap, self.minimal_keypoint_pixel_distance, self.max_keypoints)
         keypoint_probabilities = compute_keypoint_probability(heatmap, detected_keypoints)
         detected_keypoints = [
             DetectedKeypoint(detected_keypoints[i][0], detected_keypoints[i][1], keypoint_probabilities[i])

--- a/keypoint_detection/models/detector.py
+++ b/keypoint_detection/models/detector.py
@@ -89,6 +89,7 @@ class KeypointDetector(pl.LightningModule):
         ap_epoch_start: int,
         ap_epoch_freq: int,
         lr_scheduler_relative_threshold: float,
+        max_keypoints: int,
         **kwargs,
     ):
         """[summary]
@@ -115,6 +116,7 @@ class KeypointDetector(pl.LightningModule):
         self.ap_epoch_freq = ap_epoch_freq
         self.minimal_keypoint_pixel_distance = minimal_keypoint_extraction_pixel_distance
         self.lr_scheduler_relative_threshold = lr_scheduler_relative_threshold
+        self.max_keypoints = max_keypoints
         self.keypoint_channel_configuration = keypoint_channel_configuration
         # parse the gt pixel distances
         if isinstance(maximal_gt_keypoint_pixel_distances, str):

--- a/keypoint_detection/models/detector.py
+++ b/keypoint_detection/models/detector.py
@@ -72,7 +72,7 @@ class KeypointDetector(pl.LightningModule):
         )
         parser.add_argument(
             "--max_keypoints",
-            default=-1,
+            default=20,
             type=int,
             help="the maximum number of keypoints to predict from the generated heatmaps. If set to -1, skimage will look for all peaks in the heatmap, if set to N (N>0) it will return the N most most certain ones.",
         )

--- a/keypoint_detection/utils/heatmap.py
+++ b/keypoint_detection/utils/heatmap.py
@@ -78,7 +78,7 @@ def generate_channel_heatmap(
 
 
 def get_keypoints_from_heatmap(
-    heatmap: torch.Tensor, min_keypoint_pixel_distance: int, max_keypoints=0
+    heatmap: torch.Tensor, min_keypoint_pixel_distance: int, max_keypoints=-1
 ) -> List[Tuple[int, int]]:
     """
     Extracts at most 20 keypoints from a heatmap, where each keypoint is defined as being a local maximum within a 2D mask [ -min_pixel_distance, + pixel_distance]^2

--- a/keypoint_detection/utils/heatmap.py
+++ b/keypoint_detection/utils/heatmap.py
@@ -101,9 +101,13 @@ def get_keypoints_from_heatmap(
         )
     else:
         keypoints = peak_local_max(
-            np_heatmap, min_distance=min_keypoint_pixel_distance, threshold_rel=0.1, threshold_abs=0.1, num_peaks=max_keypoints
+            np_heatmap,
+            min_distance=min_keypoint_pixel_distance,
+            threshold_rel=0.1,
+            threshold_abs=0.1,
+            num_peaks=max_keypoints,
         )
-        
+
     return keypoints[::, ::-1].tolist()  # convert to (u,v) aka (col,row) coord frame from (row,col)
 
 

--- a/keypoint_detection/utils/heatmap.py
+++ b/keypoint_detection/utils/heatmap.py
@@ -78,7 +78,7 @@ def generate_channel_heatmap(
 
 
 def get_keypoints_from_heatmap(
-    heatmap: torch.Tensor, min_keypoint_pixel_distance: int, max_keypoints=-1
+    heatmap: torch.Tensor, min_keypoint_pixel_distance: int, max_keypoints: int = 20
 ) -> List[Tuple[int, int]]:
     """
     Extracts at most 20 keypoints from a heatmap, where each keypoint is defined as being a local maximum within a 2D mask [ -min_pixel_distance, + pixel_distance]^2

--- a/keypoint_detection/utils/heatmap.py
+++ b/keypoint_detection/utils/heatmap.py
@@ -78,7 +78,7 @@ def generate_channel_heatmap(
 
 
 def get_keypoints_from_heatmap(
-    heatmap: torch.Tensor, min_keypoint_pixel_distance: int, max_keypoints=None
+    heatmap: torch.Tensor, min_keypoint_pixel_distance: int, max_keypoints=0
 ) -> List[Tuple[int, int]]:
     """
     Extracts at most 20 keypoints from a heatmap, where each keypoint is defined as being a local maximum within a 2D mask [ -min_pixel_distance, + pixel_distance]^2
@@ -87,6 +87,7 @@ def get_keypoints_from_heatmap(
     Args:
         heatmap : heatmap image
         min_keypoint_pixel_distance : The size of the local mask
+        max_keypoints: the amount of keypoints to determine from the heatmap, -1 to return all points
 
     Returns:
         A list of 2D keypoints
@@ -94,13 +95,15 @@ def get_keypoints_from_heatmap(
 
     np_heatmap = heatmap.cpu().numpy().astype(np.float32)
     # num_peaks and rel_threshold are set to limit computational burden when models do random predictions.
-    if max_keypoints:
-        num_peaks = max_keypoints
+    if max_keypoints < 1:
+        keypoints = peak_local_max(
+            np_heatmap, min_distance=min_keypoint_pixel_distance, threshold_rel=0.1, threshold_abs=0.1
+        )
     else:
-        num_peaks = 20
-    keypoints = peak_local_max(
-        np_heatmap, min_distance=min_keypoint_pixel_distance, threshold_rel=0.1, threshold_abs=0.1, num_peaks=num_peaks
-    )
+        keypoints = peak_local_max(
+            np_heatmap, min_distance=min_keypoint_pixel_distance, threshold_rel=0.1, threshold_abs=0.1, num_peaks=max_keypoints
+        )
+        
     return keypoints[::, ::-1].tolist()  # convert to (u,v) aka (col,row) coord frame from (row,col)
 
 

--- a/keypoint_detection/utils/heatmap.py
+++ b/keypoint_detection/utils/heatmap.py
@@ -87,26 +87,24 @@ def get_keypoints_from_heatmap(
     Args:
         heatmap : heatmap image
         min_keypoint_pixel_distance : The size of the local mask
-        max_keypoints: the amount of keypoints to determine from the heatmap, -1 to return all points
+        max_keypoints: the amount of keypoints to determine from the heatmap, -1 to return all points. Defaults to 20 to limit computational burder
+        for models that predict random keypoints in early stage of training.
 
     Returns:
         A list of 2D keypoints
     """
 
     np_heatmap = heatmap.cpu().numpy().astype(np.float32)
+
     # num_peaks and rel_threshold are set to limit computational burden when models do random predictions.
-    if max_keypoints < 1:
-        keypoints = peak_local_max(
-            np_heatmap, min_distance=min_keypoint_pixel_distance, threshold_rel=0.1, threshold_abs=0.1
-        )
-    else:
-        keypoints = peak_local_max(
-            np_heatmap,
-            min_distance=min_keypoint_pixel_distance,
-            threshold_rel=0.1,
-            threshold_abs=0.1,
-            num_peaks=max_keypoints,
-        )
+    max_keypoints = max_keypoints if max_keypoints > 0 else np.inf
+    keypoints = peak_local_max(
+        np_heatmap,
+        min_distance=min_keypoint_pixel_distance,
+        threshold_rel=0.1,
+        threshold_abs=0.1,
+        num_peaks=max_keypoints,
+    )
 
     return keypoints[::, ::-1].tolist()  # convert to (u,v) aka (col,row) coord frame from (row,col)
 

--- a/test/configuration.py
+++ b/test/configuration.py
@@ -39,4 +39,5 @@ DEFAULT_HPARAMS = {
     "kernel_size": 3,
     "dilation": 1,
     "random-arg-to-test": "random",
+    "max_keypoints": 20
 }

--- a/test/configuration.py
+++ b/test/configuration.py
@@ -39,5 +39,5 @@ DEFAULT_HPARAMS = {
     "kernel_size": 3,
     "dilation": 1,
     "random-arg-to-test": "random",
-    "max_keypoints": 20
+    "max_keypoints": 20,
 }

--- a/test/test_heatmap.py
+++ b/test/test_heatmap.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import torch
 
 from keypoint_detection.utils.heatmap import create_heatmap_batch, generate_channel_heatmap, get_keypoints_from_heatmap
@@ -20,6 +21,18 @@ class TestHeatmapUtils(unittest.TestCase):
             self.assertTrue(keypoint in self.keypoints.tolist())
         self.assertEqual((self.image_height, self.image_width), heatmap.shape)
         self.assertGreater(heatmap[4, 10], 0.5)
+
+    def test_extract_all_keypoints_from_heatmap(self):
+        def _test_extract_keypoints_from_heatmap(keypoints, num_keypoints):
+            heatmap = generate_channel_heatmap((self.image_height, self.image_width), keypoints, self.sigma, "cpu")
+            extracted_keypoints = get_keypoints_from_heatmap(heatmap, 1, max_keypoints=num_keypoints)
+            for keypoint in extracted_keypoints:
+                self.assertTrue(keypoint in keypoints.tolist())
+
+        keypoints = torch.randint(0, 15, (500, 2))
+        _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=500)
+        _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=-1)
+        _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=np.inf)
 
     def test_empty_heatmap(self):
         # test if heatmap for channel w/o keypoints is created correctly


### PR DESCRIPTION
Added simple extra argument to choose how many keypoints to predict. By default this arg is set to -1 meaning all peaks are turned into predictions.