### PR TITLE
replace miniconda by micromamba  and cache environments

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,25 +10,14 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - name: Cache conda
-        uses: actions/cache@v2
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 1
+      - name: install conda env with micromamba
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yaml') }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: keypoint-detection # name of env
           channel-priority: strict
-          auto-activate-base: false
           environment-file: environment.yaml
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          cache-env: true
       - name: Conda list
         shell: bash -l {0}
-
         run: conda list
       - name: pytest
         shell: bash -l {0}

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-name: keypoint-detection #  to update an existing environment: conda env update -n <current_name> --file <path-to-this-file>
+name: keypoint-detection # to update an existing environment: conda env update -n <current_name> --file <path-to-this-file>
 channels:
   - pytorch
   - conda-forge

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-name: keypoint-detection # to update an existing environment: conda env update -n <current_name> --file <path-to-this-file>
+name: keypoint-detection #  to update an existing environment: conda env update -n <current_name> --file <path-to-this-file>
 channels:
   - pytorch
   - conda-forge


### PR DESCRIPTION
6m -> 3m for 'uncached'  when replacing conda with mamba
to 1m for 'cached' environment, which comes basically for free