### PR TITLE
make detector fully deterministic by default

### DIFF
--- a/keypoint_detection/models/backbones/maxvit_unet.py
+++ b/keypoint_detection/models/backbones/maxvit_unet.py
@@ -55,9 +55,8 @@ class MaxVitUnet(Backbone):
             block = UpSamplingBlock(config_in["channels"], config_skip["channels"], config_skip["channels"], 3)
             self.decoder_blocks.append(block)
 
-        self.final_upsampling_block = nn.Sequential(
-            nn.UpsamplingBilinear2d(scale_factor=2),
-            nn.Conv2d(self.feature_config[0]["channels"], self.feature_config[0]["channels"], 3, padding="same"),
+        self.final_conv = nn.Conv2d(
+            self.feature_config[0]["channels"], self.feature_config[0]["channels"], 3, padding="same"
         )
 
     def forward(self, x):
@@ -65,7 +64,8 @@ class MaxVitUnet(Backbone):
         x = features.pop(-1)
         for block in self.decoder_blocks[::-1]:
             x = block(x, features.pop(-1))
-        x = self.final_upsampling_block(x)
+        x = nn.functional.interpolate(x, scale_factor=2)
+        x = self.final_conv(x)
         return x
 
     def get_n_channels_out(self):

--- a/keypoint_detection/models/backbones/mobilenetv3.py
+++ b/keypoint_detection/models/backbones/mobilenetv3.py
@@ -25,10 +25,7 @@ class MobileNetV3(Backbone):
             block = UpSamplingBlock(channels_in, skip_channels_in, skip_channels_in, 3)
             self.decoder_blocks.append(block)
 
-        self.final_upsampling_block = nn.Sequential(
-            nn.UpsamplingBilinear2d(scale_factor=2),
-            nn.Conv2d(skip_channels_in, skip_channels_in, 3, padding="same"),
-        )
+        self.final_conv = nn.Conv2d(skip_channels_in, skip_channels_in, 3, padding="same")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         features = self.encoder(x)
@@ -36,7 +33,8 @@ class MobileNetV3(Backbone):
         x = features.pop()
         for block in self.decoder_blocks:
             x = block(x, features.pop())
-        x = self.final_upsampling_block(x)
+        x = nn.functional.interpolate(x, scale_factor=2)
+        x = self.final_conv(x)
 
         return x
 

--- a/keypoint_detection/models/backbones/unet.py
+++ b/keypoint_detection/models/backbones/unet.py
@@ -43,7 +43,6 @@ class MaxPoolDownSamplingBlock(nn.Module):
 class UpSamplingBlock(nn.Module):
     def __init__(self, n_channels_in, n_channels_out, kernel_size):
         super().__init__()
-        self.upsample = nn.UpsamplingBilinear2d(scale_factor=2)
         self.conv = nn.Conv2d(
             in_channels=n_channels_in * 2,
             out_channels=n_channels_out,
@@ -55,7 +54,7 @@ class UpSamplingBlock(nn.Module):
         self.relu = nn.ReLU()
 
     def forward(self, x, x_skip):
-        x = self.upsample(x)
+        x = nn.functional.interpolate(x, scale_factor=2)
         x = torch.cat([x, x_skip], dim=1)
         x = self.conv(x)
         x = self.relu(x)


### PR DESCRIPTION
Make pytorch fully deterministic for reproducibility. Identical runs will now result in exact same train/test/val curves and numbers.

This requires changing the upsampling mode from bilinear to nearest neighbor. Some quick experiments have indicated this does not change performance much. It is also the pytorch default.

 Used PL's trainer to accomplish this after failed attempts to do it directly in pytorch. Cf Cf. https://lightning.ai/docs/pytorch/stable/common/trainer.html#reproducibility for more info.

can turn it off with the `--no-deterministic-pytorch` CLI argument if extra performance is needed.

