### PR TITLE
Faster keypoint extraction & post-processing

### DIFF
--- a/keypoint_detection/models/detector.py
+++ b/keypoint_detection/models/detector.py
@@ -13,7 +13,7 @@ from keypoint_detection.utils.heatmap import (
     BCE_loss,
     compute_keypoint_probability,
     create_heatmap_batch,
-    get_keypoints_from_heatmap,
+    get_keypoints_from_heatmap_scipy,
 )
 from keypoint_detection.utils.visualization import visualize_predictions
 
@@ -424,7 +424,7 @@ class KeypointDetector(pl.LightningModule):
         heatmap (torch.Tensor) : H x W tensor that represents a heatmap.
         """
 
-        detected_keypoints = get_keypoints_from_heatmap(
+        detected_keypoints = get_keypoints_from_heatmap_scipy(
             heatmap, self.minimal_keypoint_pixel_distance, self.max_keypoints
         )
         keypoint_probabilities = compute_keypoint_probability(heatmap, detected_keypoints)

--- a/keypoint_detection/models/detector.py
+++ b/keypoint_detection/models/detector.py
@@ -9,13 +9,8 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from keypoint_detection.models.backbones.base_backbone import Backbone
 from keypoint_detection.models.metrics import DetectedKeypoint, Keypoint, KeypointAPMetrics
-from keypoint_detection.utils.heatmap import (
-    BCE_loss,
-    compute_keypoint_probability,
-    create_heatmap_batch,
-    get_keypoints_from_heatmap_scipy,
-)
-from keypoint_detection.utils.visualization import visualize_predictions
+from keypoint_detection.utils.heatmap import BCE_loss, create_heatmap_batch, get_keypoints_from_heatmap_batch_maxpool
+from keypoint_detection.utils.visualization import visualize_predicted_heatmaps
 
 
 class KeypointDetector(pl.LightningModule):
@@ -286,11 +281,10 @@ class KeypointDetector(pl.LightningModule):
 
         image_grids = []
         for channel_idx in range(len(self.keypoint_channel_configuration)):
-            grid = visualize_predictions(
+            grid = visualize_predicted_heatmaps(
                 input_images,
                 predicted_heatmaps[:, channel_idx, :, :],
                 gt_heatmaps[channel_idx].cpu(),
-                minimal_keypoint_pixel_distance=6,
             )
             image_grids.append(grid)
         return image_grids
@@ -312,7 +306,7 @@ class KeypointDetector(pl.LightningModule):
     def log_image_grids(self, image_grids, mode: str):
         for channel_configuration, grid in zip(self.keypoint_channel_configuration, image_grids):
             label = KeypointDetector.logging_label(channel_configuration, mode)
-            image_caption = "top: predicted heatmaps, middle: predicted keypoints, bottom: gt heatmap"
+            image_caption = "top: predicted heatmaps, bottom: gt heatmaps"
             self.logger.experiment.log({label: wandb.Image(grid, caption=image_caption)})
 
     def validation_step(self, val_batch, batch_idx):
@@ -371,21 +365,24 @@ class KeypointDetector(pl.LightningModule):
         self, predicted_heatmaps: torch.Tensor, gt_keypoints: List[torch.Tensor], validation_metric: KeypointAPMetrics
     ):
         """
-        Updates the AP metric for a batch of heatmaps and keypoins of a single channel.
+        Updates the AP metric for a batch of heatmaps and keypoins of a single channel (!)
         This is done by extracting the detected keypoints for each heatmap and combining them with the gt keypoints for the same frame, so that
         the confusion matrix can be determined together with the distance thresholds.
 
-        predicted_heatmaps: N x H x W tensor
+        predicted_heatmaps: N x H x W tensor with the batch of predicted heatmaps for a single channel
         gt_keypoints: List of size N, containing K_i x 2 tensors with the ground truth keypoints for the channel of that sample
         """
 
-        # log corner keypoints to AP metrics, frame by frame
+        # log corner keypoints to AP metrics for all images in this batch
         formatted_gt_keypoints = [
             [Keypoint(int(k[0]), int(k[1])) for k in frame_gt_keypoints] for frame_gt_keypoints in gt_keypoints
         ]
-        for i, predicted_heatmap in enumerate(torch.unbind(predicted_heatmaps, 0)):
-            detected_keypoints = self.extract_detected_keypoints_from_heatmap(predicted_heatmap)
-            validation_metric.update(detected_keypoints, formatted_gt_keypoints[i])
+        batch_detected_channel_keypoints = self.extract_detected_keypoints_from_heatmap(
+            predicted_heatmaps.unsqueeze(1)
+        )
+        batch_detected_channel_keypoints = [batch_detected_channel_keypoints[i][0] for i in range(len(gt_keypoints))]
+        for i, detected_channel_keypoints in enumerate(batch_detected_channel_keypoints):
+            validation_metric.update(detected_channel_keypoints, formatted_gt_keypoints[i])
 
     def compute_and_log_metrics_for_channel(
         self, metrics: KeypointAPMetrics, channel: str, training_mode: str
@@ -423,14 +420,21 @@ class KeypointDetector(pl.LightningModule):
         Args:
         heatmap (torch.Tensor) : H x W tensor that represents a heatmap.
         """
-
-        detected_keypoints = get_keypoints_from_heatmap_scipy(
-            heatmap, self.minimal_keypoint_pixel_distance, self.max_keypoints
+        if heatmap.dtype == torch.float16:
+            heatmap_full = heatmap.float()
+        keypoints, scores = get_keypoints_from_heatmap_batch_maxpool(
+            heatmap_full, self.max_keypoints, self.minimal_keypoint_pixel_distance, return_scores=True
         )
-        keypoint_probabilities = compute_keypoint_probability(heatmap, detected_keypoints)
-        detected_keypoints = [
-            DetectedKeypoint(detected_keypoints[i][0], detected_keypoints[i][1], keypoint_probabilities[i])
-            for i in range(len(detected_keypoints))
-        ]
+        detected_keypoints = [[[] for _ in range(heatmap_full.shape[1])] for _ in range(heatmap_full.shape[0])]
+        for batch_idx in range(len(detected_keypoints)):
+            for channel_idx in range(len(detected_keypoints[batch_idx])):
+                for kp_idx in range(len(keypoints[batch_idx][channel_idx])):
+                    detected_keypoints[batch_idx][channel_idx].append(
+                        DetectedKeypoint(
+                            keypoints[batch_idx][channel_idx][kp_idx][0],
+                            keypoints[batch_idx][channel_idx][kp_idx][1],
+                            scores[batch_idx][channel_idx][kp_idx],
+                        )
+                    )
 
         return detected_keypoints

--- a/keypoint_detection/utils/heatmap.py
+++ b/keypoint_detection/utils/heatmap.py
@@ -119,6 +119,7 @@ def get_keypoints_from_heatmap_batch_maxpool(
     min_keypoint_pixel_distance: int = 1,
     abs_max_threshold: Optional[float] = None,
     rel_max_threshold: Optional[float] = None,
+    return_scores: bool = False,
 ) -> List[List[List[Tuple[int, int]]]]:
     """Fast extraction of keypoints from a batch of heatmaps using maxpooling.
 
@@ -132,6 +133,9 @@ def get_keypoints_from_heatmap_batch_maxpool(
     Returns:
         The extracted keypoints for each batch, channel and heatmap; and their scores
     """
+
+    # TODO: ugly that the output can change based on a flag.. should always return scores and discard them when I don't need them...
+
     batch_size, n_channels, _, width = heatmap.shape
 
     # obtain max_keypoints local maxima for each channel (w/ maxpool)
@@ -177,7 +181,10 @@ def get_keypoints_from_heatmap_batch_maxpool(
                     # convert to (u,v)
                     filtered_indices[batch_idx][channel_idx].append(candidates[candidate_idx][::-1].tolist())
                     filtered_scores[batch_idx][channel_idx].append(scores[batch_idx, channel_idx, candidate_idx])
-    return filtered_indices
+    if return_scores:
+        return filtered_indices, filtered_scores
+    else:
+        return filtered_indices
 
 
 def compute_keypoint_probability(heatmap: torch.Tensor, detected_keypoints: List[Tuple[int, int]]) -> List[float]:

--- a/keypoint_detection/utils/visualization.py
+++ b/keypoint_detection/utils/visualization.py
@@ -5,7 +5,7 @@ import torch
 import torchvision
 from matplotlib import cm
 
-from keypoint_detection.utils.heatmap import generate_channel_heatmap, get_keypoints_from_heatmap_scipy
+from keypoint_detection.utils.heatmap import generate_channel_heatmap
 
 
 def overlay_image_with_heatmap(images: torch.Tensor, heatmaps: torch.Tensor, alpha=0.5) -> torch.Tensor:
@@ -49,26 +49,17 @@ def overlay_image_with_keypoints(images: torch.Tensor, keypoints: List[torch.Ten
     return overlayed_images
 
 
-def visualize_predictions(
+def visualize_predicted_heatmaps(
     imgs: torch.Tensor,
     predicted_heatmaps: torch.Tensor,
     gt_heatmaps: torch.Tensor,
-    minimal_keypoint_pixel_distance: int,
 ):
     num_images = min(predicted_heatmaps.shape[0], 6)
-    keypoint_sigma = max(1, imgs.shape[2] / 64)
 
     predicted_heatmap_overlays = overlay_image_with_heatmap(imgs[:num_images], predicted_heatmaps[:num_images])
     gt_heatmap_overlays = overlay_image_with_heatmap(imgs[:num_images], gt_heatmaps[:num_images])
-    predicted_keypoints = [
-        torch.tensor(get_keypoints_from_heatmap_scipy(predicted_heatmaps[i].cpu(), minimal_keypoint_pixel_distance))
-        for i in range(predicted_heatmaps.shape[0])
-    ]
-    predicted_keypoints_overlays = overlay_image_with_keypoints(
-        imgs[:num_images], predicted_keypoints[:num_images], keypoint_sigma
-    )
 
-    images = torch.cat([predicted_heatmap_overlays, predicted_keypoints_overlays, gt_heatmap_overlays])
+    images = torch.cat([predicted_heatmap_overlays, gt_heatmap_overlays])
     grid = torchvision.utils.make_grid(images, nrow=num_images)
     return grid
 
@@ -98,7 +89,7 @@ if __name__ == "__main__":
     shape = images.shape[2:]
 
     heatmaps = create_heatmap_batch(shape, keypoint_channels[0], sigma=6.0, device="cpu")
-    grid = visualize_predictions(images, heatmaps, heatmaps, 6)
+    grid = visualize_predicted_heatmaps(images, heatmaps, heatmaps, 6)
 
     image_numpy = grid.permute(1, 2, 0).numpy()
     plt.imshow(image_numpy)

--- a/keypoint_detection/utils/visualization.py
+++ b/keypoint_detection/utils/visualization.py
@@ -5,7 +5,7 @@ import torch
 import torchvision
 from matplotlib import cm
 
-from keypoint_detection.utils.heatmap import generate_channel_heatmap, get_keypoints_from_heatmap
+from keypoint_detection.utils.heatmap import generate_channel_heatmap, get_keypoints_from_heatmap_scipy
 
 
 def overlay_image_with_heatmap(images: torch.Tensor, heatmaps: torch.Tensor, alpha=0.5) -> torch.Tensor:
@@ -61,7 +61,7 @@ def visualize_predictions(
     predicted_heatmap_overlays = overlay_image_with_heatmap(imgs[:num_images], predicted_heatmaps[:num_images])
     gt_heatmap_overlays = overlay_image_with_heatmap(imgs[:num_images], gt_heatmaps[:num_images])
     predicted_keypoints = [
-        torch.tensor(get_keypoints_from_heatmap(predicted_heatmaps[i].cpu(), minimal_keypoint_pixel_distance))
+        torch.tensor(get_keypoints_from_heatmap_scipy(predicted_heatmaps[i].cpu(), minimal_keypoint_pixel_distance))
         for i in range(predicted_heatmaps.shape[0])
     ]
     predicted_keypoints_overlays = overlay_image_with_keypoints(

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -39,10 +39,10 @@ if __name__ == "__main__":
 
     device = "cuda:0"
     backbone = "ConvNeXtUnet"
-    input_size = 256
+    input_size = 1024
 
     backbone = BackboneFactory.create_backbone(backbone)
-    model = KeypointDetector(1, "2 4", 3, 3e-4, backbone, [["test"]], 1, 1, 0.0, 20)
+    model = KeypointDetector(1, "2 4", 3, 3e-4, backbone, [["test1"], ["test2,test3"]], 1, 1, 0.0, 20)
     # do not forget to set model to eval mode!
     # this will e.g. use the running statistics for batch norm layers instead of the batch statistics.
     # this is important as inference batches are typically a lot smaller which would create too much noise.

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
 
     device = "cuda:0"
     backbone = "ConvNeXtUnet"
-    input_size = 1024
+    input_size = 512
 
     backbone = BackboneFactory.create_backbone(backbone)
     model = KeypointDetector(1, "2 4", 3, 3e-4, backbone, [["test1"], ["test2,test3"]], 1, 1, 0.0, 20)
@@ -52,14 +52,14 @@ if __name__ == "__main__":
     sample_model_input = torch.rand(1, 3, input_size, input_size, device=device, dtype=torch.float32)
     sample_inference_input = np.random.randint(0, 255, (input_size, input_size, 3), dtype=np.uint8)
 
-    benchmark(lambda: model(sample_model_input), "plain model forward pass", profile=True)
+    benchmark(lambda: model(sample_model_input), "plain model forward pass", profile=False)
     benchmark(
-        lambda: local_inference(model, sample_inference_input, device=device), "plain model inference", profile=True
+        lambda: local_inference(model, sample_inference_input, device=device), "plain model inference", profile=False
     )
 
     torchscript_model = model.to_torchscript()
     # JIT compiling with torchscript should improve performance (slightly)
-    benchmark(lambda: torchscript_model(sample_model_input), "torchscript model forward pass", profile=True)
+    benchmark(lambda: torchscript_model(sample_model_input), "torchscript model forward pass", profile=False)
 
     torch.backends.cudnn.benchmark = True
     model.half()
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     half_torchscript_model = model.to_torchscript(method="trace", example_inputs=half_input)
 
     benchmark(
-        lambda: half_torchscript_model(half_input), "torchscript model forward pass with half precision", profile=True
+        lambda: half_torchscript_model(half_input), "torchscript model forward pass with half precision", profile=False
     )
 
     # note: from the traces it can be seen that a lot of time is spent in 'overhead', i.e. the GPU is idle...

--- a/scripts/benchmark_heatmap_extraction.py
+++ b/scripts/benchmark_heatmap_extraction.py
@@ -32,9 +32,12 @@ def test_method(nb_iters, heatmaps, method, name):
 
 if __name__ == "__main__":
     nb_iters = 20
-    n_channels = 1
+    n_channels = 2
     batch_size = 1
     n_keypoints_per_channel = 10
+    print(
+        f"benchmarking with  batch_size: {batch_size}, {n_channels} channels and {n_keypoints_per_channel} keypoints per channel"
+    )
     for heatmap_size in [(256, 256), (512, 256), (512, 512), (1920, 1080)]:
         heatmaps = [
             generate_channel_heatmap(heatmap_size, torch.randint(0, 255, (6, 2)), 6, "cpu")

--- a/scripts/benchmark_heatmap_extraction.py
+++ b/scripts/benchmark_heatmap_extraction.py
@@ -1,0 +1,49 @@
+"""quick and dirty benchmark of the heatmap extraction methods."""
+
+import time
+
+import torch
+
+from keypoint_detection.utils.heatmap import (
+    generate_channel_heatmap,
+    get_keypoints_from_heatmap_batch_maxpool,
+    get_keypoints_from_heatmap_scipy,
+)
+
+
+def test_method(nb_iters, heatmaps, method, name):
+    n_keypoints = 20
+    torch.cuda.synchronize()
+    t0 = time.time()
+    if method == get_keypoints_from_heatmap_scipy:
+        for i in range(nb_iters):
+            heatmap = heatmaps[i]
+            for batch in range(len(heatmap)):
+                for channel in range(len(heatmap[batch])):
+                    method(heatmap[batch][channel], n_keypoints)
+    else:
+        for i in range(nb_iters):
+            method(heatmaps[i], n_keypoints)
+    torch.cuda.synchronize()
+    t1 = time.time()
+    duration = (t1 - t0) / nb_iters * 1000.0
+    print(f"{duration:.3f} ms per iter for {name} method with heatmap size {heatmap_size} ")
+
+
+if __name__ == "__main__":
+    nb_iters = 20
+    n_channels = 1
+    batch_size = 1
+    n_keypoints_per_channel = 10
+    for heatmap_size in [(256, 256), (512, 256), (512, 512), (1920, 1080)]:
+        heatmaps = [
+            generate_channel_heatmap(heatmap_size, torch.randint(0, 255, (6, 2)), 6, "cpu")
+            .unsqueeze(0)
+            .unsqueeze(0)
+            .repeat(batch_size, n_channels, 1, 1)
+            .cuda()
+            for _ in range(nb_iters)
+        ]
+
+        test_method(nb_iters, heatmaps, get_keypoints_from_heatmap_scipy, "scipy")
+        test_method(nb_iters, heatmaps, get_keypoints_from_heatmap_batch_maxpool, "torch")

--- a/scripts/checkpoint_inference.py
+++ b/scripts/checkpoint_inference.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from torchvision.transforms.functional import to_tensor
 
-from keypoint_detection.utils.heatmap import get_keypoints_from_heatmap
+from keypoint_detection.utils.heatmap import get_keypoints_from_heatmap_scipy
 from keypoint_detection.utils.load_checkpoints import get_model_from_wandb_checkpoint
 
 
@@ -28,7 +28,7 @@ def local_inference(model, image: np.ndarray, device="cuda"):
 
     # extract keypoints from heatmaps
     predicted_keypoints = [
-        torch.tensor(get_keypoints_from_heatmap(heatmaps[i].cpu(), 2)) for i in range(heatmaps.shape[0])
+        torch.tensor(get_keypoints_from_heatmap_scipy(heatmaps[i].cpu(), 2)) for i in range(heatmaps.shape[0])
     ]
 
     return predicted_keypoints

--- a/scripts/checkpoint_inference.py
+++ b/scripts/checkpoint_inference.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from torchvision.transforms.functional import to_tensor
 
-from keypoint_detection.utils.heatmap import get_keypoints_from_heatmap_scipy
+from keypoint_detection.utils.heatmap import get_keypoints_from_heatmap_batch_maxpool
 from keypoint_detection.utils.load_checkpoints import get_model_from_wandb_checkpoint
 
 
@@ -27,9 +27,7 @@ def local_inference(model, image: np.ndarray, device="cuda"):
         heatmaps = model(image).squeeze(0)
 
     # extract keypoints from heatmaps
-    predicted_keypoints = [
-        torch.tensor(get_keypoints_from_heatmap_scipy(heatmaps[i].cpu(), 2)) for i in range(heatmaps.shape[0])
-    ]
+    predicted_keypoints = get_keypoints_from_heatmap_batch_maxpool(heatmaps.unsqueeze(0))[0]
 
     return predicted_keypoints
 

--- a/test/test_heatmap.py
+++ b/test/test_heatmap.py
@@ -3,7 +3,12 @@ import unittest
 import numpy as np
 import torch
 
-from keypoint_detection.utils.heatmap import create_heatmap_batch, generate_channel_heatmap, get_keypoints_from_heatmap
+from keypoint_detection.utils.heatmap import (
+    create_heatmap_batch,
+    generate_channel_heatmap,
+    get_keypoints_from_heatmap_batch_maxpool,
+    get_keypoints_from_heatmap_scipy,
+)
 
 
 class TestHeatmapUtils(unittest.TestCase):
@@ -16,23 +21,34 @@ class TestHeatmapUtils(unittest.TestCase):
     def test_keypoint_generation_and_extraction(self):
         # test if extract(generate(keypoints)) == keypoints
         heatmap = generate_channel_heatmap((self.image_height, self.image_width), self.keypoints, self.sigma, "cpu")
-        extracted_keypoints = get_keypoints_from_heatmap(heatmap, 1)
+        extracted_keypoints = get_keypoints_from_heatmap_scipy(heatmap, 1)
         for keypoint in extracted_keypoints:
             self.assertTrue(keypoint in self.keypoints.tolist())
         self.assertEqual((self.image_height, self.image_width), heatmap.shape)
         self.assertGreater(heatmap[4, 10], 0.5)
 
-    def test_extract_all_keypoints_from_heatmap(self):
+    def test_extract_all_keypoints_from_heatmap_scipy(self):
         def _test_extract_keypoints_from_heatmap(keypoints, num_keypoints):
             heatmap = generate_channel_heatmap((self.image_height, self.image_width), keypoints, self.sigma, "cpu")
-            extracted_keypoints = get_keypoints_from_heatmap(heatmap, 1, max_keypoints=num_keypoints)
+            extracted_keypoints = get_keypoints_from_heatmap_scipy(heatmap, 1, max_keypoints=num_keypoints)
             for keypoint in extracted_keypoints:
                 self.assertTrue(keypoint in keypoints.tolist())
 
-        keypoints = torch.randint(0, 15, (500, 2))
-        _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=500)
+        keypoints = torch.randint(0, 15, (5, 2))
+        _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=10)
         _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=-1)
         _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=np.inf)
+
+    def test_extract_keypoints_from_heatmap_maxpool(self):
+        def _test_extract_keypoints_from_heatmap(keypoints, num_keypoints):
+            heatmap = generate_channel_heatmap((self.image_height, self.image_width), keypoints, self.sigma, "cpu")
+            heatmap = heatmap.unsqueeze(0).unsqueeze(0)
+            extracted_keypoints = get_keypoints_from_heatmap_batch_maxpool(heatmap, max_keypoints=num_keypoints)[0][0]
+            for keypoint in extracted_keypoints:
+                self.assertTrue(keypoint in keypoints.tolist())
+
+        keypoints = torch.randint(0, 15, (5, 2))
+        _test_extract_keypoints_from_heatmap(keypoints, num_keypoints=10)
 
     def test_empty_heatmap(self):
         # test if heatmap for channel w/o keypoints is created correctly


### PR DESCRIPTION
Refactored keypoint extraction to use torch.maxpool and torch.topk instead of scipy.

Also operates on batches of channels instead of individual channels

Depending on size of heatmaps, batch_size and # keypoints, speedups are between 5x and 70x:
```
benchmarking with  batch_size: 1, 2 channels and 10 keypoints per channel

5.231 ms per iter for scipy method with heatmap size (256, 256) 
0.653 ms per iter for torch method with heatmap size (256, 256) 

8.732 ms per iter for scipy method with heatmap size (512, 256) 
0.520 ms per iter for torch method with heatmap size (512, 256) 

13.223 ms per iter for scipy method with heatmap size (512, 512) 
0.524 ms per iter for torch method with heatmap size (512, 512) 

109.976 ms per iter for scipy method with heatmap size (1920, 1080) 
1.152 ms per iter for torch method with heatmap size (1920, 1080) 
``` 

(results from `scripts/benchmark_heatmaps.py`)

This improves both inference speed and validation/test speed during training.